### PR TITLE
Fix bug with from-external get requests

### DIFF
--- a/lib/siilar/client/tracks.rb
+++ b/lib/siilar/client/tracks.rb
@@ -26,7 +26,7 @@ module Siilar
       def from_external(track)
         response = client.get("1.0/from-external/#{track}")
 
-        Struct::Track.new(response)
+        response.map { |r| Struct::Track.new(r) }
       end
 
       # Creates a track.


### PR DESCRIPTION
https://api.niland.io/doc/tracks#get-tracks-from-external actually returns an array, whereas the lib wait for a hash.