### PR TITLE
For radio operation on tracks, allow to user 'reference' argument

### DIFF
--- a/lib/siilar/client/radios.rb
+++ b/lib/siilar/client/radios.rb
@@ -53,7 +53,7 @@ module Siilar
       #
       # @see http://api.niland.io/2.0/doc/radios#notify-a-skip
       def notify_skip(radio, attributes = {})
-        Extra.validate_mandatory_attributes(attributes, [:track])
+        validate_arguments_has_track_or_reference(attributes)
         response = client.post("2.0/radios/#{radio}/skips", attributes)
         Struct::Radio.new(response)
       end
@@ -62,7 +62,7 @@ module Siilar
       #
       # @see http://api.niland.io/2.0/doc/radios#notify-a-like
       def notify_like(radio, attributes = {})
-        Extra.validate_mandatory_attributes(attributes, [:track])
+        validate_arguments_has_track_or_reference(attributes)
         response = client.post("2.0/radios/#{radio}/likes", attributes)
         Struct::Radio.new(response)
       end
@@ -71,7 +71,7 @@ module Siilar
       #
       # @see http://api.niland.io/2.0/doc/radios#notify-a-dislike
       def notify_dislike(radio, attributes = {})
-        Extra.validate_mandatory_attributes(attributes, [:track])
+        validate_arguments_has_track_or_reference(attributes)
         response = client.post("2.0/radios/#{radio}/dislikes", attributes)
         Struct::Radio.new(response)
       end
@@ -80,7 +80,7 @@ module Siilar
       #
       # @see http://api.niland.io/2.0/doc/radios#notify-a-ban
       def notify_ban(radio, attributes = {})
-        Extra.validate_mandatory_attributes(attributes, [:track])
+        validate_arguments_has_track_or_reference(attributes)
         response = client.post("2.0/radios/#{radio}/bans", attributes)
         Struct::Radio.new(response)
       end
@@ -89,7 +89,7 @@ module Siilar
       #
       # @see http://api.niland.io/2.0/doc/radios#notify-a-favorite
       def notify_favorite(radio, attributes = {})
-        Extra.validate_mandatory_attributes(attributes, [:track])
+        validate_arguments_has_track_or_reference(attributes)
         response = client.post("2.0/radios/#{radio}/favorites", attributes)
         Struct::Radio.new(response)
       end
@@ -98,10 +98,19 @@ module Siilar
       #
       # @see http://api.niland.io/2.0/doc/radios#notify-a-not-played-track
       def notify_not_played(radio, attributes = {})
-        Extra.validate_mandatory_attributes(attributes, [:track])
+        validate_arguments_has_track_or_reference(attributes)
         response = client.post("2.0/radios/#{radio}/notplayed", attributes)
         Struct::Radio.new(response)
       end
+
+      private
+ 
+      def validate_arguments_has_track_or_reference(attributes)
+        if !(attributes.key?(:track) ^ attributes.key?(:reference))
+          raise(ArgumentError, ":track or :reference is required. They are mutually exclusive")
+        end
+      end
+
     end
   end
 end

--- a/spec/siilar/client/radios_spec.rb
+++ b/spec/siilar/client/radios_spec.rb
@@ -165,12 +165,25 @@ describe Siilar::Client, '.radios' do
       stub_request(:post, %r[/2.0/radios/.+/skips]).to_return(read_fixture('radios/notify_skip/created.http'))
     end
 
-    it 'builds the correct request' do
+    it 'builds the correct request with track' do
       attributes = { track: 125052 }
       subject.notify_skip("568bb450e13aa09d878b4568", attributes)
 
       expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/skips?key=key')
                           .with(body: attributes)
+    end
+
+    it 'builds the correct request with reference' do
+      attributes = { reference: 10266 }
+      subject.notify_skip("568bb450e13aa09d878b4568", attributes)
+
+      expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/skips?key=key')
+                          .with(body: attributes)
+    end
+
+    it 'does not accept track and reference at the same time' do
+      attributes = { track: 125052, reference: 10266 }
+      expect { subject.notify_skip("568bb450e13aa09d878b4568", attributes) }.to raise_error(ArgumentError)
     end
 
     it 'returns the radio' do
@@ -187,12 +200,25 @@ describe Siilar::Client, '.radios' do
       stub_request(:post, %r[/2.0/radios/.+/likes]).to_return(read_fixture('radios/notify_like/created.http'))
     end
 
-    it 'builds the correct request' do
+    it 'builds the correct request with track' do
       attributes = { track: 125052 }
       subject.notify_like("568bb450e13aa09d878b4568", attributes)
 
       expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/likes?key=key')
                           .with(body: attributes)
+    end
+
+    it 'builds the correct request with reference' do
+      attributes = { reference: 10266 }
+      subject.notify_like("568bb450e13aa09d878b4568", attributes)
+
+      expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/likes?key=key')
+                          .with(body: attributes)
+    end
+
+    it 'does not accept track and reference at the same time' do
+      attributes = { track: 125052, reference: 10266 }
+      expect { subject.notify_skip("568bb450e13aa09d878b4568", attributes) }.to raise_error(ArgumentError)
     end
 
     it 'returns the radio' do
@@ -209,12 +235,25 @@ describe Siilar::Client, '.radios' do
       stub_request(:post, %r[/2.0/radios/.+/dislikes]).to_return(read_fixture('radios/notify_dislike/created.http'))
     end
 
-    it 'builds the correct request' do
+    it 'builds the correct request with track' do
       attributes = { track: 125052 }
       subject.notify_dislike("568bb450e13aa09d878b4568", attributes)
 
       expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/dislikes?key=key')
                           .with(body: attributes)
+    end
+
+    it 'builds the correct request with reference' do
+      attributes = { reference: 10266 }
+      subject.notify_dislike("568bb450e13aa09d878b4568", attributes)
+
+      expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/dislikes?key=key')
+                          .with(body: attributes)
+    end
+
+    it 'does not accept track and reference at the same time' do
+      attributes = { track: 125052, reference: 10266 }
+      expect { subject.notify_skip("568bb450e13aa09d878b4568", attributes) }.to raise_error(ArgumentError)
     end
 
     it 'returns the radio' do
@@ -231,12 +270,25 @@ describe Siilar::Client, '.radios' do
       stub_request(:post, %r[/2.0/radios/.+/bans]).to_return(read_fixture('radios/notify_ban/created.http'))
     end
 
-    it 'builds the correct request' do
+    it 'builds the correct request with track' do
       attributes = { track: 125052 }
       subject.notify_ban("568bb450e13aa09d878b4568", attributes)
 
       expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/bans?key=key')
                           .with(body: attributes)
+    end
+
+    it 'builds the correct request with reference' do
+      attributes = { reference: 10266 }
+      subject.notify_ban("568bb450e13aa09d878b4568", attributes)
+
+      expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/bans?key=key')
+                          .with(body: attributes)
+    end
+
+    it 'does not accept track and reference at the same time' do
+      attributes = { track: 125052, reference: 10266 }
+      expect { subject.notify_skip("568bb450e13aa09d878b4568", attributes) }.to raise_error(ArgumentError)
     end
 
     it 'returns the radio' do
@@ -253,12 +305,25 @@ describe Siilar::Client, '.radios' do
       stub_request(:post, %r[/2.0/radios/.+/favorites]).to_return(read_fixture('radios/notify_favorite/created.http'))
     end
 
-    it 'builds the correct request' do
+    it 'builds the correct request with track' do
       attributes = { track: 125052 }
       subject.notify_favorite("568bb450e13aa09d878b4568", attributes)
 
       expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/favorites?key=key')
                           .with(body: attributes)
+    end
+
+    it 'builds the correct request with reference' do
+      attributes = { reference: 10266 }
+      subject.notify_favorite("568bb450e13aa09d878b4568", attributes)
+
+      expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/favorites?key=key')
+                          .with(body: attributes)
+    end
+
+    it 'does not accept track and reference at the same time' do
+      attributes = { track: 125052, reference: 10266 }
+      expect { subject.notify_skip("568bb450e13aa09d878b4568", attributes) }.to raise_error(ArgumentError)
     end
 
     it 'returns the radio' do
@@ -275,12 +340,25 @@ describe Siilar::Client, '.radios' do
       stub_request(:post, %r[/2.0/radios/.+/notplayed]).to_return(read_fixture('radios/notify_not_played/created.http'))
     end
 
-    it 'builds the correct request' do
+    it 'builds the correct request with track' do
       attributes = { track: 125052 }
       subject.notify_not_played("568bb450e13aa09d878b4568", attributes)
 
       expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/notplayed?key=key')
                           .with(body: attributes)
+    end
+
+    it 'builds the correct request with reference' do
+      attributes = { reference: 10266 }
+      subject.notify_not_played("568bb450e13aa09d878b4568", attributes)
+
+      expect(WebMock).to have_requested(:post, 'http://api.niland/2.0/radios/568bb450e13aa09d878b4568/notplayed?key=key')
+                          .with(body: attributes)
+    end
+
+    it 'does not accept track and reference at the same time' do
+      attributes = { track: 125052, reference: 10266 }
+      expect { subject.notify_skip("568bb450e13aa09d878b4568", attributes) }.to raise_error(ArgumentError)
     end
 
     it 'returns the radio' do


### PR DESCRIPTION
I can't find documentation for API 1.0 (not online anymore) so I got my info from the doc of API 2.0. It seems to be working from trial.

For radio operations that need to identify a track (that is `/skips`, `/likes`, `/dislikes`, etc.) there is two possibility to identify the track : 

- By providing Niland track's ID, with a body of the form : 

```
{
  "track": 1
}
```

- By providing the track reference, which is equivalent to 1D touch's track ID.

```
{
  "reference": 11
}
```

This PR allows the methods of `client.radio` to accept `track` or `reference` in the arguments (both beign mutually exclusive)  